### PR TITLE
Issue #18: Add test_toml_utils.py to include test cases for load_config() 

### DIFF
--- a/tests/test_content_packager.py
+++ b/tests/test_content_packager.py
@@ -237,4 +237,4 @@ class TestCreateStructureTree:
 
     def test_for_lab8_pr(self):
         """test to check CI run in PR"""
-        assert 1 + 1 == 2
+        assert 1 + 1 == 3 # now fixed this to make CI fail

--- a/tests/test_content_packager.py
+++ b/tests/test_content_packager.py
@@ -237,4 +237,4 @@ class TestCreateStructureTree:
 
     def test_for_lab8_pr(self):
         """test to check CI run in PR"""
-        assert 1 + 1 == 3 # now fixed this to make CI fail
+        assert 1 + 1 == 2 # fixed this back to pass CLI test in PR

--- a/tests/test_content_packager.py
+++ b/tests/test_content_packager.py
@@ -234,3 +234,7 @@ class TestCreateStructureTree:
         assert "level2" in result
         assert "level3" in result
         assert "deep.txt" in result
+
+    def test_for_lab8_pr():
+        """test to check CI run in PR"""
+        assert 1 + 1 == 2

--- a/tests/test_content_packager.py
+++ b/tests/test_content_packager.py
@@ -235,6 +235,6 @@ class TestCreateStructureTree:
         assert "level3" in result
         assert "deep.txt" in result
 
-    def test_for_lab8_pr():
+    def test_for_lab8_pr(self):
         """test to check CI run in PR"""
         assert 1 + 1 == 2

--- a/tests/test_toml_utils.py
+++ b/tests/test_toml_utils.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from toml_utils import load_config
+
+class TestLoadConfig:
+    """Tests for load_config function in toml_utils.py"""
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        """Should return None if the config file does not exist"""
+        missing_file = tmp_path / "non-existent.toml"
+        result = load_config(missing_file)
+        assert result is None
+
+    def test_loads_valid_toml_config(self, tmp_path):
+        """Should correctly parse a valid TOML file"""
+        config_text = """
+        output = ""
+        tokens = false
+        recent = true
+        line_numbers = false
+        dirs_only = true
+        exclude_dirs = ["__pycache__", "venv", ".git"]
+        """
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text(config_text)
+
+        result = load_config(toml_file)
+
+        assert isinstance(result, dict)
+        assert result["output"] == ""
+        assert result["tokens"] is False
+        assert result["recent"] is True
+        assert result["dirs_only"] is True
+        assert result["exclude_dirs"] == ["__pycache__", "venv", ".git"]
+
+    def test_invalid_toml_raises_runtime_error(self, tmp_path):
+        """Should raise RuntimeError for invalid TOML file"""
+        invalid_toml = tmp_path / "bad_config.toml"
+        invalid_toml.write_text("invalid_arg")
+
+        with pytest.raises(RuntimeError) as err:
+            load_config(invalid_toml)
+
+        assert 'Cannot parse config file' in str(err.value)


### PR DESCRIPTION
Tests cases have been added to test for load_config() in toml_utils.py, and put in file tests/test_toml_utils.py for issue #18 .  
Three test cases are included:
1. case of missing TOML file, **none** should be returned
2. case of TOML file in valid format, a dictionary with correct key-value pairs should be returned
3. case of TOML file in invalid format, runtime error should be raised